### PR TITLE
Adding framework to build content (subpages) in CPT

### DIFF
--- a/classes/programes.php
+++ b/classes/programes.php
@@ -1,0 +1,8 @@
+<?php
+
+class SC_Programes extends SC_TypeBase {
+
+    public function __construct() {
+        parent::__construct('programa','programes');
+    }
+}

--- a/classes/rewriter.php
+++ b/classes/rewriter.php
@@ -1,0 +1,48 @@
+<?php
+
+class SC_Rewriter {
+
+    protected $singular;
+    protected $plural;
+
+    public function __construct($singular, $plural) {
+        $this->singular = $singular;
+        $this->plural = $plural;
+    }
+
+    public function setup_rewrite() {
+        $this->subpages_rewrite();
+        add_filter( 'page_link', array($this, 'subpages_post_link') , 10, 2 );
+    }
+
+    private function subpages_rewrite() {
+        add_rewrite_rule(
+            "$this->plural/[^&/]+/([^/]+)/?",
+            'index.php?post_type=page&pagename='. $this->get_partial_subpages_path().'$matches[1]',
+            'top'
+        );
+    }
+
+    public function subpages_post_link( $permalink, $post ) {
+
+        if ( false === strpos( $permalink, $this->get_partial_subpages_path() ) ) {
+            return $permalink;
+        }
+
+        $parent_id = get_post_meta($post, 'wpcf-'.$this->singular, true);
+
+        $parent_entity = get_post( $parent_id );
+
+        if ( $parent_entity !== null ) {
+            $slug = $parent_entity->post_name;
+        } else {
+            $slug = '';
+        }
+
+        return str_replace( "%$this->singular%", $slug , $permalink );
+    }
+
+    private function get_partial_subpages_path() {
+        return "subpagines-$this->plural/";
+    }
+}

--- a/classes/typebase.php
+++ b/classes/typebase.php
@@ -1,0 +1,34 @@
+<?php
+
+class SC_TypeBase {
+
+    var $rewriter;
+    var $type_helper;
+
+    var $singular;
+
+    public function __construct($singular, $plural) {
+        $this->singular = $singular;
+        $this->rewriter = new SC_Rewriter($singular,$plural);
+        $this->rewriter->setup_rewrite();
+
+        $this->type_helper = new SC_TypeHelper($singular);
+
+        add_filter('wpt_field_options', array( $this, 'custom_select'), 10, 3);
+    }
+
+    public function get_info_for_select() {
+        return $this->type_helper->get_info_for_select();
+    }    
+
+    public function custom_select( $options, $title, $type )
+    {
+        switch( strtolower( $title ) )
+        {
+            case $this->singular:
+                $options = $this->get_info_for_select();
+            break;
+        }
+        return $options;
+    }
+}

--- a/classes/typehelper.php
+++ b/classes/typehelper.php
@@ -1,0 +1,30 @@
+<?php
+
+class SC_TypeHelper {
+
+    public $type;
+
+    public function __construct( $type ) {
+        $this->type = $type;
+    }
+
+    function get_info_for_select() {
+        $query = new WP_Query();
+        
+        $args = array(
+                'post_type'        => $this->type,
+                'post_status'      => 'publish',
+                'no_found_rows'    => true,
+                'posts_per_page'      => -1
+        );
+        
+        $all_programs = $query->query( $args );
+
+        return array_map( function ($entry) {
+            return array(
+                '#value' => $entry->ID,
+                '#title' => $entry->post_title,
+            );
+        }, $all_programs );
+    }
+}

--- a/functions.php
+++ b/functions.php
@@ -52,7 +52,6 @@ class StarterSite extends TimberSite {
         global $sc_types;
 
         $sc_types['programes'] = new SC_Programes();
-        $sc_types['esdeveniments'] = new SC_Esdeveniments();
     }
 
     function register_taxonomies() {

--- a/functions.php
+++ b/functions.php
@@ -11,8 +11,11 @@ if ( ! class_exists( 'Timber' ) && is_admin() ) {
     die();
 }
 
-
 Timber::$dirname = array('templates', 'views');
+
+global $sc_types;
+
+$sc_types = array();
 
 class StarterSite extends TimberSite {
 
@@ -24,13 +27,32 @@ class StarterSite extends TimberSite {
         add_filter( 'timber_context', array( $this, 'add_user_nav_info_to_context' ) );
         add_filter( 'get_twig', array( $this, 'add_to_twig' ) );
         add_action( 'init', array( $this, 'register_post_types' ) );
-        add_action( 'init', array( $this, 'register_taxonomies' ) );
         add_action( 'template_redirect', array( $this, 'fix_woosidebar_hooks'), 1);
+        add_action( 'after_setup_theme', array( $this, 'include_theme_conf' ) );
+
+        spl_autoload_register( array( $this, 'autoload' ) );
+
         parent::__construct();
     }
 
+    function autoload($cls) {
+        $path =  __DIR__ . '/classes/' . strtolower(str_replace('SC_', '', $cls)) . '.php';
+
+        is_readable($path) && require_once($path);
+    }
+
+    function include_theme_conf() {
+        locate_template( array( 'inc/widgets.php' ), true, true );
+        locate_template( array( 'inc/post_types_functions.php' ), true, true );
+        locate_template( array( 'inc/shortcodes-llistes.php' ), true, true );
+        locate_template( array( 'inc/ajax_operations.php' ), true, true );
+    }
+
     function register_post_types() {
-        //this is where you can register custom post types
+        global $sc_types;
+
+        $sc_types['programes'] = new SC_Programes();
+        $sc_types['esdeveniments'] = new SC_Esdeveniments();
     }
 
     function register_taxonomies() {
@@ -192,15 +214,6 @@ function get_category_id( $slug ) {
     $category_id = $category->term_id;
     return $category_id;
 }
-
-function include_theme_conf()
-{
-    locate_template( array( 'inc/widgets.php' ), true, true );
-    locate_template( array( 'inc/post_types_functions.php' ), true, true );
-    locate_template( array( 'inc/shortcodes-llistes.php' ), true, true );
-    locate_template( array( 'inc/ajax_operations.php' ), true, true );
-}
-add_action( 'after_setup_theme', 'include_theme_conf' );
 
 function retrieve_page_data($page_slug = '')
 {


### PR DESCRIPTION
Aquest framework permet definir pàgines que estaran "baix" de qualsevol Custom Post Type (ex. `/programes/firexox/dubtes-mes-frequents/`).

Suposem que volem habilitar el funcionament per al CPT **Programes**. Per a que tota la infrastructura comence a funcionar _automàgicament_, només cal fer el següent 

>  ATENCIÓ: els noms de les coses que apareixen en negreta són molt importants

1.  Crear una pàgina "pare" per a totes les subpàgines de programes, anomenada **`subpagines-programes`**
2. Crear una nova plantilla que compartiran totes les subpàgines (o diverses, si és necessari).
3. Al Types, definir un nou grup de custom fields amb un select anomenat **programa**, i assignar-lo per a que es mostre només en la plantilla o plantilles creades en el punt 2 
 * Crec també es pot fer utilitzant jerarquia de pàgines, però segurament preferim la opció anterior
4. Ja es pot crear contingut de manera senzilla des del menú de les pàgines. Només cal definir, en el nou select box que apareixerà, quin és el programa al que volem associar la pàgina.