### PR TITLE
Add new languages and fixes

### DIFF
--- a/static/js/traductor.js
+++ b/static/js/traductor.js
@@ -343,7 +343,6 @@ function translateText() {
            if (jQuery('#log_traductor_source:checked').length)
                 savetext = true;
             
-            
            $.ajax({
                 url:neuronal_json_url + `/translate/`,
                 type:"POST",
@@ -616,8 +615,10 @@ var neuronalApp = (function () {
         var origin_language = jQuery('#origin_language').val();
         var target_language = jQuery('#target_language').val();
         var rneuronalchecked = jQuery("#rneuronal").is(':checked');
+        var neuronal_langs = ["en", "deu", "ita", "nld", "fr", "pt"]
 
-        if (((origin_language == 'en') || (target_language == 'en') || (origin_language == 'de') || (target_language == 'de')) & rneuronalchecked)
+        if ((jQuery.inArray(origin_language, neuronal_langs) !== -1 || jQuery.inArray(target_language, neuronal_langs) !== -1)
+            & rneuronalchecked)
             return true;
         else
             return false;
@@ -629,33 +630,24 @@ var neuronalApp = (function () {
         var origin_lang  = jQuery('#origin_language').val();
         var target_lang = jQuery('#target_language').val();
         var rneuronalchecked = jQuery("#rneuronal").is(':checked');
+        var langs_with_both_translators = ["en", "fr", "pt"]
         
-        if ((origin_lang == 'en') || (target_lang == 'en') || (origin_lang == 'de') || (target_lang == 'de')){
-
-        if ((origin_lang == 'de') || (target_lang == 'de')){
+        if (jQuery.inArray(origin_lang, langs_with_both_translators) !== -1 ||
+            jQuery.inArray(target_lang, langs_with_both_translators) !== -1) {
 
             jQuery('#rneuronal').prop("checked", true);
-            jQuery('#rapertium').attr('disabled', true);
 
-        }else{
-            jQuery('#rapertium').attr('disabled', false);
-        }
-        
             // Show radiobuttons for neuronal vs apertium
             jQuery('#panel-radioneuronal').removeClass('hidden');
             jQuery('#panel-radioneuronal').show();
     
             if (rneuronalchecked){       
                 show_neuronal_menu();
-
-                
-
             }else{
                 hide_neuronal_menu();
             }
       
         }else{
-    
             // Hide radiobuttons
             jQuery('#panel-radioneuronal').hide();
             jQuery('#info-neuronal').hide();

--- a/templates/traductor.twig
+++ b/templates/traductor.twig
@@ -27,12 +27,14 @@
                       <div id="div_select_origin">
                       <select class="form-control selectpicker bt" id="origin-select">
                         <option value="en" selected="selected">Anglès</option>
-                        <option value="de">Alemany</option>
+                        <option value="deu">Alemany</option>
                         <option value="oc">Occità/Aranès</option>
                         <option value="ron">Romanès</option>
                         <option value="fr">Francès</option>
                         <option value="pt">Portuguès</option>
                         <option value="arg">Aragonès</option>
+                        <option value="nld">Holandès</option>
+                        <option value="ita">Italià</option>
                       </select>
                       </div><!--/dropdown llengues -->
 
@@ -40,7 +42,7 @@
                       <div id="div_select_origin_mobile">
                       <select class="form-control selectpicker selectpicker-mobil visible-xs-block" id="origin-select-mobil">
                         <option value="en">Anglès</option>
-                        <option value="de">Alemany</option>
+                        <option value="deu">Alemany</option>
                         <option value="cat">Català</option>
                         <option value="spa">Castellà</option>
                         <option value="oc">Occità/Aranès</option>
@@ -48,6 +50,8 @@
                         <option value="arg">Aragonès</option>
                         <option value="fr">Francès</option>
                         <option value="pt">Portuguès</option>
+                        <option value="nld">Holandès</option>
+                        <option value="ita">Italià</option>
                       </select>
                       </div><!--/dropdown llengues mòbil -->
                     </div>
@@ -65,12 +69,14 @@
                         <div id="div_select_target">
                         <select class="form-control selectpicker bt" id="target-select">
                           <option value="en">Anglès</option>
-                          <option value="de">Alemany</option>
+                          <option value="deu">Alemany</option>
                           <option value="oc">Occità/Aranès</option>
                           <option value="ron">Romanès</option>
                           <option value="fr">Francès</option>
                           <option value="pt">Portuguès</option>
                           <option value="arg">Aragonès</option>
+                          <option value="nld">Holandès</option>
+                          <option value="ita">Italià</option>
                         </select>
                         </div><!--/dropdown llengues -->
 
@@ -78,7 +84,7 @@
                         <div id="div_select_target_mobile">
                         <select class="form-control selectpicker selectpicker-mobil visible-xs-inline-block" id="target-select-mobil">
                           <option value="en">Anglès</option>
-                          <option value="de">Alemany</option>
+                          <option value="deu">Alemany</option>
                           <option value="cat">Català</option>
                           <option value="spa" selected="selected">Castellà</option>
                           <option value="oc">Occità/Aranès</option>
@@ -86,6 +92,8 @@
                           <option value="arg">Aragonès</option>
                           <option value="fr">Francès</option>
                           <option value="pt">Portuguès</option>
+                          <option value="nld">Holandès</option>
+                          <option value="ita">Italià</option>
                         </select>
                         </div><!--/dropdown llengues mòbil -->
                       </div>
@@ -204,8 +212,16 @@
                          <select class="form-control selectpicker" name="n_model_name" id="n_model_name">
                           <option value="cat-deu">Català -> Alemany</option>
                           <option value="cat-eng">Català -> Anglès</option>
+                          <option value="cat-fra">Català -> Francès</option>
+                          <option value="cat-nld">Català -> Holandès</option>
+                          <option value="cat-ita">Català -> Italià</option>
+                          <option value="cat-por">Català -> Portuguès</option>
                           <option value="eng-cat" selected>Anglès -> Català</option>
                           <option value="deu-cat">Alemany -> Català</option>
+                          <option value="fra-cat">Francès -> Català</option>
+                          <option value="nld-cat">Holandès -> Català</option>
+                          <option value="ita-cat">Italià -> Català</option>
+                          <option value="por-cat">Portuguès -> Català</option>
                         </select>
                       </div>
                     </div>


### PR DESCRIPTION
Changes
* Adds the translation to nld (Dutch) and ita (Italian) from the translation text box. These language pairs are currently not offered by Apertium
* Adds the translation to nld (Dutch), ita (Italian), fra (French) and por (Portuguese) using files send by email. Translation using email services only uses neuronal translation
* Fixes bug: in production German (deu) shows Apertium and Neuronal, but Apertium does not offer this language, only neuronal  (as result, we shoud not be showing the radio buttons to select which translator you want to use)
* Changed the language code of German from "de" to "deu" since 3 letters is the default used by the neuronal translator (except when languages are shared with Aperitum, e.g. "en", "pt")
* Adds fr (French) and pt (Portuguese) neuronal translation from the translationt text box making it the default option (Apertium offers them too, then the option of using Apertium is activated for these languages)