### PR TITLE
Initial version

### DIFF
--- a/classes/settings.php
+++ b/classes/settings.php
@@ -14,11 +14,13 @@ class SC_Settings extends SC_Singleton {
 	const SETTINGS_LOG_CORRECTOR_USER_EVENTS = 'log_corrector_user_events';
 	const SETTINGS_SEND_EMAILS_THESAURUS_ERRORS = 'send_emails_thesaurus_error';
 	const SETTINGS_LOG_TRADUCTOR_SOURCE = 'log_traductor_source';
+	const SETTINGS_CORRECTOR_SEND_SESSIONID = 'corrector_send_sessionid';
 
 	const SETTINGS = array(
 		self::SETTINGS_LOG_CORRECTOR_USER_EVENTS,
 		self::SETTINGS_SEND_EMAILS_THESAURUS_ERRORS,
 		self::SETTINGS_LOG_TRADUCTOR_SOURCE,
+		self::SETTINGS_CORRECTOR_SEND_SESSIONID,
 	);
 
 	public function get_setting_names() {

--- a/corrector.php
+++ b/corrector.php
@@ -22,6 +22,8 @@ wp_localize_script( 'sc-js-corrector-1', 'scajax', array(
 
 $context = Timber::get_context();
 $context['api_languagetool'] = get_option('api_languagetool');
+$settings = SC_Settings::get_instance();
+$context['corrector_send_sessionid'] = $settings->get_setting(SC_Settings::SETTINGS_CORRECTOR_SEND_SESSIONID);
 
 //Ads
 $context['ads_container'] = true;

--- a/static/js/languagetool.js
+++ b/static/js/languagetool.js
@@ -4,6 +4,7 @@ var regles_amb_checkbox = Array('recomana_preferents', 'evita_colloquials', 'esp
 var langCode="ca-ES";
 var userOptions="";
 var SC_COOKIE = 'sc-languagetool';
+var SC_COOKIE_SESSIONID = 'sc-languagetool-sessionid';
 var placeholdervisible = true;
 
 (function($) {
@@ -376,7 +377,19 @@ function dooptions() {
         "disabledCategories.ca-ES-valencia=" + disabledCategories.join() + "\n"
         );
 
-    userOptions="&level=picky"; 
+    userOptions="&level=picky";
+
+    if (corrector_send_sessionid) {
+		var value = jQuery.getCookie(SC_COOKIE_SESSIONID);
+		if (value !== 'undefined') {
+			var session_id = value;
+		} else {
+			var session_id = Date.now();
+			jQuery.setCookie(SC_COOKIE_SESSIONID, session_id);
+		}
+		userOptions += "&sessionID=" + session_id
+	}
+
     if (jQuery("input[name=variant]:checked").val() == "variant_valencia") {
   langCode="ca-ES-valencia";
         if (disabledRules.join()) { userOptions += "&disabledRules=" + disabledRules.join(); }

--- a/templates/admin/sc-dash.twig
+++ b/templates/admin/sc-dash.twig
@@ -63,6 +63,21 @@
                             {% endif %}
                         </td>
                     </tr>
+                    <tr>
+                        <th scope="row">
+                            <label>
+                                    <strong>LanguageTool</strong>
+                                    Habilita/deshabilita l'enviament del textSessionId per a experiments
+                            </label>
+                        </th>
+                        <td>
+                            {% if settings.get_setting(constant('SC_Settings::SETTINGS_CORRECTOR_SEND_SESSIONID')) %}
+                                <input type="checkbox" checked="checked" id="{{ constant('SC_Settings::SETTINGS_CORRECTOR_SEND_SESSIONID') }}" name="{{ constant('SC_Settings::SETTINGS_CORRECTOR_SEND_SESSIONID') }}">
+                            {% else %}
+                                <input type="checkbox" id="{{ constant('SC_Settings::SETTINGS_CORRECTOR_SEND_SESSIONID') }}" name="{{ constant('SC_Settings::SETTINGS_CORRECTOR_SEND_SESSIONID') }}">
+                            {% endif %}
+                        </td>
+                    </tr>
                     </tbody></table>
                 </p>
             </div>

--- a/templates/corrector.twig
+++ b/templates/corrector.twig
@@ -3,6 +3,7 @@
 {% block content %}
     <script type="text/javascript">
       var languagetool_rpc_url = '{{ api_languagetool }}';
+      var corrector_send_sessionid = '{{ corrector_send_sessionid }}';
     </script>
     <!-- .main .wrap-blanc -->
     <main class="main wrap-blanc cd-main-content">


### PR DESCRIPTION
Aquí hi ha una descripció complet del projecte:
https://docs.google.com/document/d/11eToHs5E3Dz3MlKB4EUqNkxm-jLcg0F-uz9tnyd9I54/edit#

Secció "Experiment a producció"

La idea és que si a les preferències del Wordpress tenim l'opció "Habilita/deshabilita l'enviament del textSessionId per a experiments", llavors en la trucada POST a languageTool passem un sessionID que és genera per usuari. 

La idea és que l'ID es guardi entre trucades al corrector perquè amb aquest ID decidirem si l'usuari està o no a l'experiment (basant-nos en el ID) i llavors es important que ID no canvi entre sessions.