### PR TITLE
Remove pre GA 4 tracking code no longer needed 

### DIFF
--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -238,27 +238,6 @@
 
 
 <!-- Analytics -->
-<script type="text/javascript">
-
-  /* Google Analytics */
-
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-150131-4', 'auto');
-  ga('set', 'anonymizeIp', true);
-
-  if (document.body.classList.contains('error404')) {
-    ga('send', 'pageview', '404/' + document.location.pathname);
-  } else if (typeof sc_analytics_page !== "undefined") {
-    ga('send', 'pageview', sc_analytics_page);
-  } else {
-    ga('send', 'pageview');
-  }
-</script>
-    
     <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-8L2DZMHJ4K"></script>
 <script>


### PR DESCRIPTION
Entenc que aquest codi ja no cal ja que aquest sistema de tracking anterior a GA4 es va deprecar a juliol de 2023 i vam migrar a GA 4. Amb el     <!-- Google tag (gtag.js) --> de sota tindriem prou.