### PR TITLE
When loading the page, give priority to the first image and lazy load…

### DIFF
--- a/templates/slider.twig
+++ b/templates/slider.twig
@@ -13,7 +13,13 @@
     {% for slide in slides %}
     <div class="item {% if loop.first %}active{% endif %}">
       <a href="{{ slide.slide_link }}" title="{{ slide.title }}">
-        <img src="{{ slide.thumbnail.src }}" alt="{{ slide.title }}" />
+        <img src="{{ slide.thumbnail.src }}" alt="{{ slide.title }}"
+          {% if loop.first %}
+             fetchpriority="high"
+           {% else %}
+             loading="lazy"
+           {% endif %} />
+         />
         {% if slide.title or slide.post_excerpt %}
           <div class="carousel-caption">
           {% if slide.title %}


### PR DESCRIPTION
Basat amb el que ens diu: https://pagespeed.web.dev/analysis/https-www-softcatala-org/qenx5k4gkc?form_factor=desktop

La idea és:
- La primera imatge donar-li prioritat (que no ho fem)
- Carregar la resta d'images només quan es necessari per no carregar la pimera pàgina

