### PR TITLE
Switch to jquery minified

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -462,7 +462,7 @@ function softcatala_scripts() {
 	global $sc_site;
 
 	wp_deregister_script( 'jquery' );
-	wp_register_script( 'jquery', includes_url( '/js/jquery/jquery.js' ), false, null, true );
+	wp_register_script( 'jquery', includes_url( '/js/jquery/jquery.min.js' ), false, null, true );
 
 	wp_register_script( 'sc-js-metacookie', get_template_directory_uri() . '/static/js/jquery.metacookie.js', array( 'jquery' ), '20210928', true );
 


### PR DESCRIPTION
Seguint aquestes indicacions:

<img width="856" height="252" alt="Captura de pantalla 2025-08-01 a les 15 40 11" src="https://github.com/user-attachments/assets/8e1cf865-ed6f-4032-b59e-129050a83170" />

Sembla que el WP ho pot fer sol si canviem a WP_DEBUG a producció i carregem differrent l'JS ho fa sol, però aquest era el canvi mínim en línea amb el que hi ha
