### PR TITLE
Fixes case in canonical for letters in conjugador

### DIFF
--- a/classes/conjugador.php
+++ b/classes/conjugador.php
@@ -149,15 +149,12 @@ class SC_Conjugador {
 			'verbs' =>  $api_result
 		);
 
-		$canonical = '/conjugador-de-verbs/lletra/'. $lletra .'/';
-		
-						
 		$model = array(
 			'lletra' => $lletra,
 			'verbs' =>  $api_result
 		);
 		
-		$canonical = '/conjugador-de-verbs/lletra/'. $lletra .'/';
+		$canonical = '/conjugador-de-verbs/lletra/'. strtoupper($lletra) .'/';
 		$title = 'Conjugador de verbs: verbs que comencen per ' . $lletra;
 		$content_title =  'Conjugador de verbs. Verbs que comencen per la lletra «' . $lletra . '»';
 		$description = "'Conjugador de verbs: verbs que comencen per ' . $lletra;";
@@ -276,7 +273,7 @@ class SC_Conjugador {
 
 	private function returnNoindexresults( $lletra ){
 
-		$canonical = '/conjugador-de-verbs/lletra/'. $lletra .'/';
+		$canonical = '/conjugador-de-verbs/lletra/'. strtoupper($lletra) .'/';
 		$title = 'Conjugador de verbs: verbs que comencen per ' . $lletra;
 		$content_title =  'Conjugador de verbs. Verbs que comencen per la lletra «' . $lletra . '»';
 		$description = 'Conjugador de verbs: verbs que comencen per ' . $lletra;


### PR DESCRIPTION
In the conjugador, all the links in the letters index are in upper case:

https://www.softcatala.org/diccionari-angles-catala/eng/lletra/H/

but then the canonical are in lower case:

https://www.softcatala.org/diccionari-angles-catala/eng/lletra/h/

This PR fixes the canonical to match the page that we use and our preferred option in this and others dicts