### PR TITLE
Switch to absolute canonical URLs

### DIFF
--- a/classes/conjugador.php
+++ b/classes/conjugador.php
@@ -154,7 +154,7 @@ class SC_Conjugador {
 			'verbs' =>  $api_result
 		);
 		
-		$canonical = '/conjugador-de-verbs/lletra/'. strtoupper($lletra) .'/';
+		$canonical = home_url() . '/conjugador-de-verbs/lletra/'. strtoupper($lletra) .'/';
 		$title = 'Conjugador de verbs: verbs que comencen per ' . $lletra;
 		$content_title =  'Conjugador de verbs. Verbs que comencen per la lletra «' . $lletra . '»';
 		$description = "'Conjugador de verbs: verbs que comencen per ' . $lletra;";
@@ -169,7 +169,7 @@ class SC_Conjugador {
 		
 		throw_error( '404', 'No Results For This Search' );
 
-		$canonical = '/conjugador-de-verbs/';
+		$canonical = home_url() . '/conjugador-de-verbs/';
 		$title = 'Conjugador de verbs | Softcatalà';
 		$content_title =  'Conjugador de verbs.  «' . $verb . '»';
 		$description = $verb;
@@ -231,7 +231,7 @@ class SC_Conjugador {
 			$title         = 'Conjugació en català del verb ' . $infinitive_title . ' | Softcatalà';
 			$content_title = 'Conjugació en català del verb «' . $infinitive_title . '»';
 
-			$canonical = '/conjugador-de-verbs/verb/'. $infinitiu .'/';
+			$canonical = home_url() . '/conjugador-de-verbs/verb/'. $infinitiu .'/';
 			
 			$temps = array(	'singular1' => 'jo',
 							'singular2' => 'tu',
@@ -273,7 +273,7 @@ class SC_Conjugador {
 
 	private function returnNoindexresults( $lletra ){
 
-		$canonical = '/conjugador-de-verbs/lletra/'. strtoupper($lletra) .'/';
+		$canonical = home_url() . '/conjugador-de-verbs/lletra/'. strtoupper($lletra) .'/';
 		$title = 'Conjugador de verbs: verbs que comencen per ' . $lletra;
 		$content_title =  'Conjugador de verbs. Verbs que comencen per la lletra «' . $lletra . '»';
 		$description = 'Conjugador de verbs: verbs que comencen per ' . $lletra;
@@ -288,7 +288,7 @@ class SC_Conjugador {
 
 	private function returnInfinitives( $api_result , $verb ){
 		
-		$canonical = '/conjugador-de-verbs/';
+		$canonical = home_url() . '/conjugador-de-verbs/';
 		$title = 'Conjugació del verb ' . $verb;
 		$content_title =  'Conjugació del verb «' . $verb . '»';
 		$description = 'Conjugació del verb «' . $verb . '»';

--- a/classes/diccionari-engcat.php
+++ b/classes/diccionari-engcat.php
@@ -83,7 +83,7 @@ class SC_Diccionari_engcat {
 			$html       = 'Resultats de la cerca per a «<strong>' . $paraula . '</strong>»';
 	
 			$canonical_lemma = isset($result->canonicalLemma) ? $result->canonicalLemma : $paraula;
-			$canonical = '/diccionari-angles-catala'.'/paraula/' . $canonical_lemma . '/';
+			$canonical = home_url() . '/diccionari-angles-catala'.'/paraula/' . $canonical_lemma . '/';
 			
 			foreach ( $result->results as $index => $single_entry ) {
 				
@@ -143,7 +143,7 @@ class SC_Diccionari_engcat {
 
 		$html       = 'Paraules i expressions en '.$llengua_str.' que comencen per: «<strong>' . $lletra . '</strong>» (' . $result_count . ' ' . $result_count_word . ') <hr class="clara"/>';
 
-		$canonical = '/diccionari-angles-catala/' . $llengua . '/lletra/' . strtoupper($lletra) . '/';
+		$canonical = home_url() . '/diccionari-angles-catala/' . $llengua . '/lletra/' . strtoupper($lletra) . '/';
 
 		$html .= Timber::fetch( 'ajax/diccionaris-lletra.twig',
 			array(

--- a/classes/sinonims.php
+++ b/classes/sinonims.php
@@ -97,7 +97,7 @@ class SC_Sinonims {
 
 		$html       = 'Paraules i expressions que comencen per: «<strong>' . $lletra . '</strong>» (' . $result_count . ' ' . $result_count_word . ') <hr class="clara"/>';
 
-		$canonical = '/diccionari-de-sinonims/lletra/' . strtoupper($lletra) . '/';
+		$canonical = home_url() . '/diccionari-de-sinonims/lletra/' . strtoupper($lletra) . '/';
 
 		$html .= Timber::fetch( 'ajax/diccionaris-lletra.twig',
 			array(
@@ -124,7 +124,7 @@ class SC_Sinonims {
 			$html       = 'Resultats de la cerca per a «<strong>' . $paraula . '</strong>» (' . $result_count . ' ' . $result_count_word . ') <hr class="clara"/>';
 
 			$canonical_lemma = isset($result->canonicalLemma) ? $result->canonicalLemma : $paraula;
-			$canonical = '/diccionari-de-sinonims/paraula/' . $canonical_lemma . '/';
+			$canonical = home_url() . '/diccionari-de-sinonims/paraula/' . $canonical_lemma . '/';
 
 			if ( isset($result->alternatives) && count($result->alternatives) >= 1 ) {
 				$html .= '<em>' . Timber::fetch( 'ajax/sinonims-alternatives.twig', array( 'alternatives' => $result->alternatives ) ) . '</em>';


### PR DESCRIPTION
Feedback from  PageInsights:

<img width="786" height="55" alt="Captura de pantalla 2025-09-20 a les 19 24 02" src="https://github.com/user-attachments/assets/106609a9-e9a7-4947-b81a-5f680a734728" />

It is also a recommendation of Google web master guidelines:

<img width="1017" height="199" alt="Captura de pantalla 2025-09-20 a les 19 37 20" src="https://github.com/user-attachments/assets/d8eec466-2581-46aa-b20d-599ef1bde489" />
